### PR TITLE
Remove deprecated `:bottle unneeded`

### DIFF
--- a/Formula/clojure.rb
+++ b/Formula/clojure.rb
@@ -5,8 +5,6 @@ class Clojure < Formula
   sha256 "7da84b6908d00e748c2c46ad23e383ede59cf18bf3ae449b1c30cd6a50b80ef6"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "rlwrap"
 
   uses_from_macos "ruby" => :build


### PR DESCRIPTION
Closes #3 

Fixes this warning with recent homebrew versions:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the clojure/tools tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/clojure/homebrew-tools/Formula/clojure.rb:8
```

As per this discussion, the call can just be removed:
https://github.com/Homebrew/discussions/discussions/2311#discussioncomment-1507233